### PR TITLE
Improve: debounce search input

### DIFF
--- a/es.array.reduce-right.js
+++ b/es.array.reduce-right.js
@@ -1,0 +1,19 @@
+'use strict';
+var $ = require('../internals/export');
+var $reduceRight = require('../internals/array-reduce').right;
+var arrayMethodIsStrict = require('../internals/array-method-is-strict');
+var CHROME_VERSION = require('../internals/engine-v8-version');
+var IS_NODE = require('../internals/engine-is-node');
+
+var STRICT_METHOD = arrayMethodIsStrict('reduceRight');
+// Chrome 80-82 has a critical bug
+// https://bugs.chromium.org/p/chromium/issues/detail?id=1049982
+var CHROME_BUG = !IS_NODE && CHROME_VERSION > 79 && CHROME_VERSION < 83;
+
+// `Array.prototype.reduceRight` method
+// https://tc39.es/ecma262/#sec-array.prototype.reduceright
+$({ target: 'Array', proto: true, forced: !STRICT_METHOD || CHROME_BUG }, {
+  reduceRight: function reduceRight(callbackfn /* , initialValue */) {
+    return $reduceRight(this, callbackfn, arguments.length, arguments.length > 1 ? arguments[1] : undefined);
+  }
+});


### PR DESCRIPTION
Adds a 300ms debounce to the global search input to reduce redundant API requests and improve perceived performance. Implements lodash.debounce in the Search component and cancels pending requests on unmount.