### PR TITLE
Improve button focus outline

### DIFF
--- a/IframeRole.js
+++ b/IframeRole.js
@@ -1,0 +1,17 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var IframeRole = {
+  relatedConcepts: [{
+    module: 'HTML',
+    concept: {
+      name: 'iframe'
+    }
+  }],
+  type: 'window'
+};
+var _default = IframeRole;
+exports["default"] = _default;


### PR DESCRIPTION
Improve keyboard focus visibility for primary and ghost buttons by using the global focus ring token to meet contrast and accessibility guidelines. Proposed change: update button CSS to apply --focus-ring-color with a 3px outline offset and add :focus-visible to avoid mouse-triggered outlines.